### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/nuts3745/dev/security/code-scanning/1](https://github.com/nuts3745/dev/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily interacts with repository contents (e.g., checking out code), it only needs `contents: read` permission. This change will ensure that the workflow does not inadvertently have more access than necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
