### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nuts3745/dev/security/code-scanning/2](https://github.com/nuts3745/dev/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily interacts with the repository contents (e.g., checking out code), the `contents: read` permission is sufficient. This permission ensures that the workflow can read the repository contents without granting unnecessary write access.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
